### PR TITLE
Document dev vault path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,7 @@ The TODO.md should be:
 - Development vault used for manual testing is located at `/home/drj/VAULTS/copilot-test`.
 - For technical debt and known issues, see [`TECHDEBT.md`](./docs/TECHDEBT.md)
 - For current development session planning, see [`TODO.md`](./TODO.md)
+- **Absolutely do not open pull requests against `logancyang/obsidian-copilot` master unless the user explicitly requests it.**
 
 ### Obsidian Plugin Environment
 


### PR DESCRIPTION
Add guidance for agents about the dev vault location and reiterate that upstream PRs should only be opened on request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AGENTS.md to clarify contribution policy: do not open pull requests against the logancyang/obsidian-copilot master branch unless explicitly requested.
  * Improves guidance for contributors and sets expectations for PR submissions.
  * No changes to product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->